### PR TITLE
Read endpoint scheme from the configuration

### DIFF
--- a/src/scytale/primaryHandler.go
+++ b/src/scytale/primaryHandler.go
@@ -188,8 +188,13 @@ func addWebhooks(r *mux.Router, authHandler *alice.Chain, v *viper.Viper, logger
 	baseRouter.Handle("/hook", authHandler.ThenFunc(webHookRegistry.UpdateRegistry))
 	baseRouter.Handle("/hooks", authHandler.ThenFunc(webHookRegistry.GetRegistry))
 
+	scheme := v.GetString("scheme")
+	if len(scheme) < 1 {
+		scheme = "https"
+	}
+
 	selfURL := &url.URL{
-		Scheme: "https",
+		Scheme: scheme,
 		Host:   v.GetString("fqdn") + v.GetString("primary.address"),
 	}
 


### PR DESCRIPTION
This change allows us to configure Scytale to receive AWS notifications in an insecure endpoint.
By default it will use HTTPS.

Although we do not use it in production scenarios, this is useful in development scenarios where we do not use HTTPS.