### PR TITLE
security: patch golang version related CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xmidt-org/scytale
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/go-kit/kit v0.13.0


### PR DESCRIPTION
- CVE-2026-32289
- CVE-2026-33810
- CVE-2026-32283
- CVE-2026-33814
- CVE-2026-32281
- CVE-2026-32280
- CVE-2026-39836
- CVE-2026-27145
- CVE-2026-42507
- CVE-2026-42505